### PR TITLE
change description for task

### DIFF
--- a/src/toHex.js
+++ b/src/toHex.js
@@ -3,7 +3,7 @@
 /**
  * The function takes a number and returns
  * its hexadecimal representation as a lower
- * case string. For example 256 is converted
+ * case string. For example 255 is converted
  * то 'ff'. You should not use .toString() method.
  *
  * Conversion algorithm:


### PR DESCRIPTION
mistake in this string "For example 256 is converted то 'ff'. You should not use .toString() method."